### PR TITLE
PRO-5546: Caveat payment callback

### DIFF
--- a/charts/probate-orchestrator-service/values.aat.template.yaml
+++ b/charts/probate-orchestrator-service/values.aat.template.yaml
@@ -5,6 +5,7 @@ java:
     SERVICES_CORECASEDATA_BASEURL : "http://ccd-data-store-api-aat.service.core-compute-aat.internal"
     SERVICES_AUTH_PROVIDER_BASEURL : "http://rpe-service-auth-provider-aat.service.core-compute-aat.internal"
     AUTH_IDAM_CLIENT_BASEURL : "https://idam-api.aat.platform.hmcts.net"
-    SUBMIT_SERVICE_API_URL : "http://probate-submit-service-aat.service.core-compute-aat.internal"
+    #SUBMIT_SERVICE_API_URL : "http://probate-submit-service-aat.service.core-compute-aat.internal"
+    SUBMIT_SERVICE_API_URL : "http://probate-submit-service-pr-183.service.core-compute-preview.internal"
     BUSINESS_SERVICE_API_URL : "http://probate-business-service-aat.service.core-compute-aat.internal"
     BACK_OFFICE_API_URL: "http://probate-back-office-aat.service.core-compute-aat.internal"

--- a/charts/probate-orchestrator-service/values.aat.template.yaml
+++ b/charts/probate-orchestrator-service/values.aat.template.yaml
@@ -5,7 +5,6 @@ java:
     SERVICES_CORECASEDATA_BASEURL : "http://ccd-data-store-api-aat.service.core-compute-aat.internal"
     SERVICES_AUTH_PROVIDER_BASEURL : "http://rpe-service-auth-provider-aat.service.core-compute-aat.internal"
     AUTH_IDAM_CLIENT_BASEURL : "https://idam-api.aat.platform.hmcts.net"
-    #SUBMIT_SERVICE_API_URL : "http://probate-submit-service-aat.service.core-compute-aat.internal"
-    SUBMIT_SERVICE_API_URL : "http://probate-submit-service-pr-183.service.core-compute-preview.internal"
+    SUBMIT_SERVICE_API_URL : "http://probate-submit-service-aat.service.core-compute-aat.internal"
     BUSINESS_SERVICE_API_URL : "http://probate-business-service-aat.service.core-compute-aat.internal"
     BACK_OFFICE_API_URL: "http://probate-back-office-aat.service.core-compute-aat.internal"

--- a/src/main/java/uk/gov/hmcts/probate/client/SubmitServiceApi.java
+++ b/src/main/java/uk/gov/hmcts/probate/client/SubmitServiceApi.java
@@ -34,13 +34,13 @@ public interface SubmitServiceApi {
     );
 
     @GetMapping(
-            value = "/cases/ccd/{caseId}",
+            value = "/cases",
             headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE
     )
     ProbateCaseDetails getCaseById(
             @RequestHeader(AUTHORIZATION) String authorisation,
             @RequestHeader(SubmitServiceConfiguration.SERVICE_AUTHORIZATION) String serviceAuthorization,
-            @PathVariable(SubmitServiceConfiguration.CASE_ID) String caseId
+            @RequestParam(SubmitServiceConfiguration.CASE_ID) String caseId
     );
 
     @PostMapping(

--- a/src/main/java/uk/gov/hmcts/probate/client/SubmitServiceApi.java
+++ b/src/main/java/uk/gov/hmcts/probate/client/SubmitServiceApi.java
@@ -33,6 +33,16 @@ public interface SubmitServiceApi {
             @RequestParam("caseType") String caseType
     );
 
+    @GetMapping(
+            value = "/cases/ccd/{caseId}",
+            headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE
+    )
+    ProbateCaseDetails getCaseById(
+            @RequestHeader(AUTHORIZATION) String authorisation,
+            @RequestHeader(SubmitServiceConfiguration.SERVICE_AUTHORIZATION) String serviceAuthorization,
+            @PathVariable(SubmitServiceConfiguration.CASE_ID) String caseId
+    );
+
     @PostMapping(
             value = "/drafts/{applicationId}",
             headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE
@@ -89,13 +99,13 @@ public interface SubmitServiceApi {
     );
 
     @PostMapping(
-        value = "/ccd-case-payments/{caseId}",
-        headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE
+            value = "/ccd-case-update/{caseId}",
+            headers = CONTENT_TYPE + "=" + APPLICATION_JSON_VALUE
     )
-    ProbateCaseDetails updatePaymentsByCaseId(
+    ProbateCaseDetails updateByCaseId(
         @RequestHeader(AUTHORIZATION) String authorisation,
         @RequestHeader(SubmitServiceConfiguration.SERVICE_AUTHORIZATION) String serviceAuthorization,
-        @PathVariable("caseId") String caseId,
-        @RequestBody ProbatePaymentDetails probatePaymentDetails
+        @PathVariable(SubmitServiceConfiguration.CASE_ID) String caseId,
+        @RequestBody ProbateCaseDetails probateCaseDetails
     );
 }

--- a/src/main/java/uk/gov/hmcts/probate/client/SubmitServiceConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/probate/client/SubmitServiceConfiguration.java
@@ -11,6 +11,8 @@ class SubmitServiceConfiguration {
     static final String SERVICE_AUTHORIZATION = "ServiceAuthorization";
 
     static final String APPLICATION_ID = "applicationId";
+    
+    static final String CASE_ID = "caseId";
 
     @Bean
     @Primary

--- a/src/main/java/uk/gov/hmcts/probate/core/service/SubmitServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/probate/core/service/SubmitServiceImpl.java
@@ -150,15 +150,13 @@ public class SubmitServiceImpl implements SubmitService {
     }
 
     @Override
-    public ProbateCaseDetails updatePaymentsByCaseId(String caseId, CasePayment casePayment) {
-        log.info("Call to submit service with id {} with payment reference {}", caseId, casePayment.getReference());
-        ProbateCaseDetails probateCaseDetails = submitServiceApi.updatePaymentsByCaseId(
+    public ProbateCaseDetails updateByCaseId(String caseId, ProbateCaseDetails caseDetails) {
+        log.info("Call to submit service with id {}", caseId);
+        ProbateCaseDetails probateCaseDetails = submitServiceApi.updateByCaseId(
             securityUtils.getAuthorisation(),
             securityUtils.getServiceAuthorisation(),
             caseId,
-            ProbatePaymentDetails.builder()
-                .payment(casePayment)
-                .build());
+            caseDetails);
         return probateCaseDetails;
     }
 

--- a/src/main/java/uk/gov/hmcts/probate/service/SubmitService.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/SubmitService.java
@@ -1,6 +1,9 @@
 package uk.gov.hmcts.probate.service;
 
+import java.util.Optional;
+
 import uk.gov.hmcts.reform.probate.model.ProbateType;
+import uk.gov.hmcts.reform.probate.model.cases.CaseData;
 import uk.gov.hmcts.reform.probate.model.cases.CasePayment;
 import uk.gov.hmcts.reform.probate.model.cases.ProbateCaseDetails;
 import uk.gov.hmcts.reform.probate.model.forms.Form;
@@ -17,6 +20,8 @@ public interface SubmitService {
 
     Form updatePayments(String identifier, Form form);
 
-    ProbateCaseDetails updatePaymentsByCaseId(String caseId, CasePayment casePayment);
+    Optional<CaseData> sendNotification(ProbateCaseDetails probateCaseDetails);
+
+    ProbateCaseDetails updateByCaseId(String caseId, ProbateCaseDetails probateCaseDetails);
 
 }

--- a/src/test/java/uk/gov/hmcts/probate/core/service/PaymentUpdateServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/core/service/PaymentUpdateServiceImplTest.java
@@ -1,14 +1,23 @@
 package uk.gov.hmcts.probate.core.service;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import uk.gov.hmcts.probate.client.SubmitServiceApi;
+import uk.gov.hmcts.probate.core.service.mapper.CaveatMapper;
 import uk.gov.hmcts.probate.core.service.mapper.PaymentDtoMapper;
 import uk.gov.hmcts.probate.service.SubmitService;
 import uk.gov.hmcts.reform.probate.model.PaymentStatus;
+import uk.gov.hmcts.reform.probate.model.cases.CaseData;
 import uk.gov.hmcts.reform.probate.model.cases.CasePayment;
+import uk.gov.hmcts.reform.probate.model.cases.ProbateCaseDetails;
+import uk.gov.hmcts.reform.probate.model.cases.caveat.CaveatData;
 import uk.gov.hmcts.reform.probate.model.payments.PaymentDto;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -20,9 +29,15 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class PaymentUpdateServiceImplTest {
 
-    public static final String CCD_CASE_NUMBER = "12312";
+    private static final String SERVICE_AUTHORIZATION = "SERVICEAUTH1234567";
+    private static final String AUTHORIZATION = "AUTH1234567";
+    private static final String CCD_CASE_NUMBER = "12312";
+
     @Mock
     private SubmitService submitService;
+
+    @Mock
+    private SubmitServiceApi submitServiceApi;
 
     @Mock
     private PaymentDtoMapper paymentDtoMapper;
@@ -33,6 +48,11 @@ public class PaymentUpdateServiceImplTest {
     @InjectMocks
     private PaymentUpdateServiceImpl paymentUpdateService;
 
+    @Before
+    public void setUp() {
+        Mockito.when(securityUtils.getAuthorisation()).thenReturn(AUTHORIZATION);
+        Mockito.when(securityUtils.getServiceAuthorisation()).thenReturn(SERVICE_AUTHORIZATION);
+    }
 
     @Test
     public void shouldMakePaymentUpdateWhenPaymentStatusIsSuccess() {
@@ -40,14 +60,18 @@ public class PaymentUpdateServiceImplTest {
             .ccdCaseNumber(CCD_CASE_NUMBER)
             .status(PaymentStatus.SUCCESS.getName())
             .build();
+        ProbateCaseDetails caseDetails = ProbateCaseDetails.builder()
+            .caseData(CaveatData.builder().build())
+            .build();
+
         CasePayment casePayment = CasePayment.builder().build();
         when(paymentDtoMapper.toCasePayment(paymentDto)).thenReturn(casePayment);
-
+        when(submitServiceApi.getCaseById(eq(AUTHORIZATION), eq(SERVICE_AUTHORIZATION), eq(CCD_CASE_NUMBER))).thenReturn(caseDetails);
         paymentUpdateService.paymentUpdate(paymentDto);
 
         verify(securityUtils).setSecurityContextUserAsCaseworker();
         verify(paymentDtoMapper).toCasePayment(paymentDto);
-        verify(submitService).updatePaymentsByCaseId(CCD_CASE_NUMBER, casePayment);
+        verify(submitService).updateByCaseId(CCD_CASE_NUMBER, caseDetails);
     }
 
     @Test
@@ -59,6 +83,6 @@ public class PaymentUpdateServiceImplTest {
 
         verify(securityUtils, never()).setSecurityContextUserAsCaseworker();
         verify(paymentDtoMapper, never()).toCasePayment(paymentDto);
-        verify(submitService, never()).updatePaymentsByCaseId(eq(CCD_CASE_NUMBER), any(CasePayment.class));
+        verify(submitService, never()).updateByCaseId(eq(CCD_CASE_NUMBER), any(ProbateCaseDetails.class));
     }
 }

--- a/src/test/java/uk/gov/hmcts/probate/core/service/SubmitServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/core/service/SubmitServiceImplTest.java
@@ -288,7 +288,6 @@ public class SubmitServiceImplTest {
         verify(securityUtils, times(1)).getServiceAuthorisation();
     }
 
-
     @Test(expected = IllegalArgumentException.class)
     public void shouldThrowErrorOnUpdatePaymentsIfNoPaymentsOnForm() {
         intestacyForm.setPayments(null);
@@ -306,15 +305,11 @@ public class SubmitServiceImplTest {
             .caseData(CaveatData.builder().build())
             .build();
 
-        when(submitServiceApi.updatePaymentsByCaseId(eq(AUTHORIZATION), eq(SERVICE_AUTHORIZATION), eq(caseId), eq(ProbatePaymentDetails.builder()
-            .payment(casePayment)
-            .build()))).thenReturn(probateCaseDetails);
+        when(submitServiceApi.updateByCaseId(eq(AUTHORIZATION), eq(SERVICE_AUTHORIZATION), eq(caseId), eq(probateCaseDetails))).thenReturn(probateCaseDetails);
 
-        ProbateCaseDetails probateCaseDetailsResult = submitService.updatePaymentsByCaseId(caseId, casePayment);
+        ProbateCaseDetails probateCaseDetailsResult = submitService.updateByCaseId(caseId, probateCaseDetails);
         assertThat(probateCaseDetails, equalTo(probateCaseDetailsResult));
-        verify(submitServiceApi).updatePaymentsByCaseId(eq(AUTHORIZATION), eq(SERVICE_AUTHORIZATION), eq(caseId), eq(ProbatePaymentDetails.builder()
-            .payment(casePayment)
-            .build()));
+        verify(submitServiceApi).updateByCaseId(eq(AUTHORIZATION), eq(SERVICE_AUTHORIZATION), eq(caseId), eq(probateCaseDetails));
         verify(backOfficeService, never()).sendNotification(caveatCaseDetails);
     }
 
@@ -328,14 +323,10 @@ public class SubmitServiceImplTest {
             .caseData(CaveatData.builder().build())
             .build();
 
-        when(submitServiceApi.updatePaymentsByCaseId(eq(AUTHORIZATION), eq(SERVICE_AUTHORIZATION), eq(caseId), eq(ProbatePaymentDetails.builder()
-            .payment(casePayment)
-            .build()))).thenReturn(probateCaseDetails);
+        when(submitServiceApi.updateByCaseId(eq(AUTHORIZATION), eq(SERVICE_AUTHORIZATION), eq(caseId), eq(probateCaseDetails))).thenReturn(probateCaseDetails);
 
-        ProbateCaseDetails probateCaseDetailsResult = submitService.updatePaymentsByCaseId(caseId, casePayment);
+        ProbateCaseDetails probateCaseDetailsResult = submitService.updateByCaseId(caseId, probateCaseDetails);
         assertThat(probateCaseDetails, equalTo(probateCaseDetailsResult));
-        verify(submitServiceApi).updatePaymentsByCaseId(eq(AUTHORIZATION), eq(SERVICE_AUTHORIZATION), eq(caseId), eq(ProbatePaymentDetails.builder()
-            .payment(casePayment)
-            .build()));
+        verify(submitServiceApi).updateByCaseId(eq(AUTHORIZATION), eq(SERVICE_AUTHORIZATION), eq(caseId), eq(probateCaseDetails));
     }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PRO-5546

### Change description ###
Update to add payment callback for caveats. Code update a caveat stop application and sends email notification which is reported in the CCD case.

Please see PRO-5546 for more details including postman test data, although PR's will use GovPay scheduled service for initiating the callback.

**Does this PR introduce a breaking change?** (check one with "x")
This doesn't introduce a breaking change however for the functionality to be used PRO-5546 branches for probate-submit-service, probate-caveats-frontend and probate-back-office also need to be pushed.

```
[ ] Yes
[x] No
```
