### PR TITLE
DTSPB-1867: upgrade spring boot from 2.3.4 to 2.4.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
     id 'application'
     id 'pmd'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
-    id 'org.springframework.boot' version '2.3.4.RELEASE'
+    id 'org.springframework.boot' version '2.4.2'
     id 'com.github.ben-manes.versions' version '0.38.0'
     id 'com.gorylenko.gradle-git-properties' version '2.0.0'
     id 'info.solidsoft.pitest' version '1.5.2'
@@ -167,7 +167,7 @@ def versions = [
         lombok                          : '1.18.8',
         springfoxSwagger                : '2.10.5',
         springCloudWiremock             : '2.1.5.RELEASE',
-        springBootVersion               : '2.3.4.RELEASE',
+        springBootVersion               : '2.4.2',
         springSecurityVersion           : '5.3.5.RELEASE',
         mapStruct                       : '1.3.0.Final',
         authCheckerLib                  : '2.1.4',

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-springcloud_version=Finchley.SR1
+springcloud_version=2020.0.0
 pact_version=3.5.20


### PR DESCRIPTION



### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPB-1867

### Change description ###

upgrade springboot version for probate orchestrator service to 2.4.2

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
