### PR TITLE
DTSBP-1902 bump com.gorylenko.gradle-git-properties from 2 to 2.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
     id 'org.springframework.boot' version '2.3.4.RELEASE'
     id 'com.github.ben-manes.versions' version '0.38.0'
-    id 'com.gorylenko.gradle-git-properties' version '2.0.0'
+    id 'com.gorylenko.gradle-git-properties' version '2.3.0'
     id 'info.solidsoft.pitest' version '1.5.2'
     id 'au.com.dius.pact' version '3.5.24'
     id 'uk.gov.hmcts.java' version '0.12.2'


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPB-1902


### Change description ###
bump up dependencies


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
