### PR TITLE
DTSPB-4664 Convert GETs to POSTs so we do not log parameters

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -171,7 +171,7 @@ def versions = [
         mapStruct                       : '1.3.0.Final',
         pact_version                    : '4.1.34',
         piTest                          : '1.19.1',
-        probateCommonsVersion           : '2.0.57',
+        probateCommonsVersion           : '2.1.0',
         restAssured                     : '5.5.1',
         serenity                        : '4.2.22',
         serviceAuthProviderClient       : '5.3.0',

--- a/src/contractTest/java/uk/gov/hmcts/probate/contract/tests/BusinessServiceInviteConsumerTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/probate/contract/tests/BusinessServiceInviteConsumerTest.java
@@ -94,11 +94,11 @@ public class BusinessServiceInviteConsumerTest {
         // @formatter:off
         return builder
                 .given("business service generates pin number")
-                .uponReceiving("a request to GET a pin number ")
+                .uponReceiving("a POST to generate a pin number ")
                 .path("/pin")
-                .method("GET")
-                .matchQuery("phoneNumber", "07986777788")
-                .headers("Session-Id", SOME_SESSION_ID)
+                .method("POST")
+                .headers(CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE, "Session-Id", SOME_SESSION_ID)
+                .body(contractTestUtils.createJsonObject("/invite/requestPin.json"))
                 .willRespondWith()
                 .status(200)
                 .matchHeader("FormDataContent-Type", "text/plain;charset=UTF-8")

--- a/src/contractTest/java/uk/gov/hmcts/probate/contract/tests/BusinessServiceInviteConsumerTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/probate/contract/tests/BusinessServiceInviteConsumerTest.java
@@ -16,6 +16,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.hmcts.probate.client.business.BusinessServiceApi;
+import uk.gov.hmcts.reform.probate.model.PhonePin;
 
 import java.io.IOException;
 
@@ -123,7 +124,7 @@ public class BusinessServiceInviteConsumerTest {
     @Test
     @PactTestFor(pactMethod = "executePinNumber")
     public void verifyExecutePinNumber() throws JSONException, IOException {
-        businessServiceApi.pinNumber("07986777788", SOME_SESSION_ID);
+        businessServiceApi.pinNumberPost(SOME_SESSION_ID, new PhonePin("07986777788"));
     }
 }
 

--- a/src/contractTest/java/uk/gov/hmcts/probate/contract/tests/InvitePinNumberControllerProviderTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/probate/contract/tests/InvitePinNumberControllerProviderTest.java
@@ -6,9 +6,11 @@ import org.json.JSONException;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import uk.gov.hmcts.probate.client.business.BusinessServiceApi;
 import uk.gov.hmcts.probate.core.service.SecurityUtils;
+import uk.gov.hmcts.reform.probate.model.PhonePin;
 
 import java.io.IOException;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
@@ -26,7 +28,8 @@ public class InvitePinNumberControllerProviderTest extends ControllerProviderTes
 
         when(securityUtils.getAuthorisation()).thenReturn("authToken");
         when(securityUtils.getServiceAuthorisation()).thenReturn("someServiceAuthorisation");
-        when(businessServiceApi.pinNumber(anyString(), anyString())).thenReturn("123457");
+        when(businessServiceApi.pinNumberPost(anyString(), any(PhonePin.class)))
+                .thenReturn("123457");
 
     }
 

--- a/src/contractTest/resources/json/invite/requestPin.json
+++ b/src/contractTest/resources/json/invite/requestPin.json
@@ -1,0 +1,5 @@
+{
+  "PhonePin": {
+    "phoneNumber": "07986777788"
+  }
+}

--- a/src/integrationTest/java/uk/gov/hmcts/probate/controller/InvitationControllerIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/probate/controller/InvitationControllerIT.java
@@ -1,6 +1,7 @@
 package uk.gov.hmcts.probate.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.http.HttpHeaders;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -119,12 +120,20 @@ public class InvitationControllerIT {
     public void pinRequest_shouldReturn200() throws Exception {
         final String phoneNumber = "07987676542";
         final PhonePin phonePin = new PhonePin(phoneNumber);
+        final String requestContent = new StringBuilder()
+                .append("{")
+                .append("\"phoneNumber\": \"")
+                .append(phoneNumber)
+                .append("\"")
+                .append("}")
+                .toString();
         when(businessService.getPinNumber(eq(phonePin), eq("someSessionId"), eq(Boolean.FALSE)))
             .thenReturn("54321");
 
-        mockMvc.perform(get(InvitationController.INVITE_PIN_URL)
+        mockMvc.perform(post(InvitationController.INVITE_PIN_URL)
                 .header("Session-Id", "someSessionId")
-                .param("phoneNumber", phoneNumber))
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .content(requestContent))
                 .andExpect(status().isOk());
         verify(businessService, times(1))
                 .getPinNumber(eq(phonePin), eq("someSessionId"), eq(Boolean.FALSE));
@@ -134,13 +143,21 @@ public class InvitationControllerIT {
     public void bilingualPinRequest_shouldReturn200() throws Exception {
         final String phoneNumber = "07987676542";
         final PhonePin phonePin = new PhonePin(phoneNumber);
+        final String requestContent = new StringBuilder()
+                .append("{")
+                .append("\"phoneNumber\": \"")
+                .append(phoneNumber)
+                .append("\"")
+                .append("}")
+                .toString();
 
         when(businessService.getPinNumber(eq(phonePin), eq("someSessionId"),
             eq(Boolean.TRUE))).thenReturn("54321");
 
-        mockMvc.perform(get(InvitationController.INVITE_PIN_BILINGUAL_URL)
+        mockMvc.perform(post(InvitationController.INVITE_PIN_BILINGUAL_URL)
                 .header("Session-Id", "someSessionId")
-                .param("phoneNumber", phoneNumber))
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .content(requestContent))
                 .andExpect(status().isOk());
         verify(businessService, times(1))
                 .getPinNumber(eq(phonePin), eq("someSessionId"), eq(Boolean.TRUE));

--- a/src/integrationTest/java/uk/gov/hmcts/probate/controller/InvitationControllerIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/probate/controller/InvitationControllerIT.java
@@ -23,7 +23,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -120,23 +122,63 @@ public class InvitationControllerIT {
     public void pinRequest_shouldReturn200() throws Exception {
         final String phoneNumber = "07987676542";
         final PhonePin phonePin = new PhonePin(phoneNumber);
-        final String requestContent = new StringBuilder()
-                .append("{")
-                .append("\"phoneNumber\": \"")
-                .append(phoneNumber)
-                .append("\"")
-                .append("}")
-                .toString();
+        final String requestContent = String.format("""
+                {
+                  "phoneNumber": "%s"
+                }""",
+                phoneNumber);
+
         when(businessService.getPinNumber(eq(phonePin), eq("someSessionId"), eq(Boolean.FALSE)))
-            .thenReturn("54321");
+                .thenReturn("54321");
 
         mockMvc.perform(post(InvitationController.INVITE_PIN_URL)
-                .header("Session-Id", "someSessionId")
-                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-                .content(requestContent))
+                        .header("Session-Id", "someSessionId")
+                        .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                        .content(requestContent))
                 .andExpect(status().isOk());
         verify(businessService, times(1))
                 .getPinNumber(eq(phonePin), eq("someSessionId"), eq(Boolean.FALSE));
+    }
+
+    @Test
+    public void pinRequest_withMissingField_shouldReturn400() throws Exception {
+        final String requestContent = "{}";
+
+        mockMvc.perform(post(InvitationController.INVITE_PIN_URL)
+                        .header("Session-Id", "someSessionId")
+                        .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                        .content(requestContent))
+                .andExpect(status().is4xxClientError());
+        verify(businessService, never())
+                .getPinNumber(any(), any(), any());
+    }
+
+    @Test
+    public void pinRequest_withMisspelledField_shouldReturn400() throws Exception {
+        final String phoneNumber = "07987676542";
+        final String requestContent = String.format("""
+                {
+                  "phone": "%s"
+                }""",
+                phoneNumber);
+
+        mockMvc.perform(post(InvitationController.INVITE_PIN_URL)
+                        .header("Session-Id", "someSessionId")
+                        .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                        .content(requestContent))
+                .andExpect(status().is4xxClientError());
+        verify(businessService, never())
+                .getPinNumber(any(), any(), any());
+    }
+
+    @Test
+    public void pinRequest_withNoBody_shouldReturn400() throws Exception {
+        mockMvc.perform(post(InvitationController.INVITE_PIN_URL)
+                        .header("Session-Id", "someSessionId")
+                        .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE))
+                .andExpect(status().is4xxClientError());
+        verify(businessService, never())
+                .getPinNumber(any(), any(), any());
     }
 
     @Test
@@ -161,6 +203,47 @@ public class InvitationControllerIT {
                 .andExpect(status().isOk());
         verify(businessService, times(1))
                 .getPinNumber(eq(phonePin), eq("someSessionId"), eq(Boolean.TRUE));
+    }
+
+    @Test
+    public void bilingualPinRequest_withMissingField_shouldReturn400() throws Exception {
+        final String requestContent = "{}";
+
+        mockMvc.perform(post(InvitationController.INVITE_PIN_BILINGUAL_URL)
+                        .header("Session-Id", "someSessionId")
+                        .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                        .content(requestContent))
+                .andExpect(status().is4xxClientError());
+        verify(businessService, never())
+                .getPinNumber(any(), any(), any());
+    }
+
+    @Test
+    public void bilingualPinRequest_withMisspelledField_shouldReturn400() throws Exception {
+        final String phoneNumber = "07987676542";
+        final String requestContent = String.format("""
+                {
+                  "phone": "%s"
+                }""",
+                phoneNumber);
+
+        mockMvc.perform(post(InvitationController.INVITE_PIN_BILINGUAL_URL)
+                        .header("Session-Id", "someSessionId")
+                        .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                        .content(requestContent))
+                .andExpect(status().is4xxClientError());
+        verify(businessService, never())
+                .getPinNumber(any(), any(), any());
+    }
+
+    @Test
+    public void bilingualPinRequest_withNoBody_shouldReturn400() throws Exception {
+        mockMvc.perform(post(InvitationController.INVITE_PIN_BILINGUAL_URL)
+                        .header("Session-Id", "someSessionId")
+                        .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE))
+                .andExpect(status().is4xxClientError());
+        verify(businessService, never())
+                .getPinNumber(any(), any(), any());
     }
 
     @Test

--- a/src/integrationTest/java/uk/gov/hmcts/probate/controller/InvitationControllerIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/probate/controller/InvitationControllerIT.java
@@ -15,6 +15,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import uk.gov.hmcts.probate.TestUtils;
 import uk.gov.hmcts.probate.service.BusinessService;
+import uk.gov.hmcts.reform.probate.model.PhonePin;
 import uk.gov.hmcts.reform.probate.model.multiapplicant.Invitation;
 
 import java.util.ArrayList;
@@ -116,30 +117,33 @@ public class InvitationControllerIT {
 
     @Test
     public void pinRequest_shouldReturn200() throws Exception {
-
-        when(businessService.getPinNumber(eq("07987676542"), eq("someSessionId"), eq(Boolean.FALSE)))
+        final String phoneNumber = "07987676542";
+        final PhonePin phonePin = new PhonePin(phoneNumber);
+        when(businessService.getPinNumber(eq(phonePin), eq("someSessionId"), eq(Boolean.FALSE)))
             .thenReturn("54321");
 
         mockMvc.perform(get(InvitationController.INVITE_PIN_URL)
                 .header("Session-Id", "someSessionId")
-                .param("phoneNumber", "07987676542"))
+                .param("phoneNumber", phoneNumber))
                 .andExpect(status().isOk());
-        verify(businessService, times(1)).getPinNumber(eq("07987676542"),
-            eq("someSessionId"), eq(Boolean.FALSE));
+        verify(businessService, times(1))
+                .getPinNumber(eq(phonePin), eq("someSessionId"), eq(Boolean.FALSE));
     }
 
     @Test
     public void bilingualPinRequest_shouldReturn200() throws Exception {
+        final String phoneNumber = "07987676542";
+        final PhonePin phonePin = new PhonePin(phoneNumber);
 
-        when(businessService.getPinNumber(eq("07987676542"), eq("someSessionId"),
+        when(businessService.getPinNumber(eq(phonePin), eq("someSessionId"),
             eq(Boolean.TRUE))).thenReturn("54321");
 
         mockMvc.perform(get(InvitationController.INVITE_PIN_BILINGUAL_URL)
                 .header("Session-Id", "someSessionId")
-                .param("phoneNumber", "07987676542"))
+                .param("phoneNumber", phoneNumber))
                 .andExpect(status().isOk());
-        verify(businessService, times(1)).getPinNumber(eq("07987676542"),
-            eq("someSessionId"), eq(Boolean.TRUE));
+        verify(businessService, times(1))
+                .getPinNumber(eq(phonePin), eq("someSessionId"), eq(Boolean.TRUE));
     }
 
     @Test

--- a/src/main/java/uk/gov/hmcts/probate/client/business/BusinessServiceApi.java
+++ b/src/main/java/uk/gov/hmcts/probate/client/business/BusinessServiceApi.java
@@ -2,12 +2,10 @@ package uk.gov.hmcts.probate.client.business;
 
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestParam;
 import uk.gov.hmcts.reform.probate.model.PhonePin;
 import uk.gov.hmcts.reform.probate.model.documents.BulkScanCoverSheet;
 import uk.gov.hmcts.reform.probate.model.documents.CheckAnswersSummary;
@@ -85,9 +83,6 @@ public interface BusinessServiceApi {
                          @RequestBody Invitation invitation,
                          @RequestHeader("Session-Id") String sessionId);
 
-    @GetMapping(path = "/pin")
-    String pinNumber(@RequestParam("phoneNumber") String phoneNumber, @RequestHeader("Session-Id") String sessionId);
-
     @PostMapping(path = "/pin", consumes = MediaType.APPLICATION_JSON_VALUE)
     String pinNumberPost(
             @RequestHeader("Session-Id") String sessionId,
@@ -132,10 +127,6 @@ public interface BusinessServiceApi {
 
     @PostMapping(path = "/document-upload-issue-notification", consumes = MediaType.APPLICATION_JSON_VALUE)
     String documentUploadIssue(@RequestBody DocumentNotification executorNotification);
-
-    @GetMapping(path = "/pin/bilingual")
-    String pinNumberBilingual(@RequestParam("phoneNumber") String phoneNumber,
-                              @RequestHeader("Session-Id") String sessionId);
 
     @PostMapping(path = "/pin/bilingual", consumes = MediaType.APPLICATION_JSON_VALUE)
     String pinNumberBilingualPost(

--- a/src/main/java/uk/gov/hmcts/probate/client/business/BusinessServiceApi.java
+++ b/src/main/java/uk/gov/hmcts/probate/client/business/BusinessServiceApi.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
+import uk.gov.hmcts.reform.probate.model.PhonePin;
 import uk.gov.hmcts.reform.probate.model.documents.BulkScanCoverSheet;
 import uk.gov.hmcts.reform.probate.model.documents.CheckAnswersSummary;
 import uk.gov.hmcts.reform.probate.model.documents.DocumentNotification;
@@ -87,6 +88,11 @@ public interface BusinessServiceApi {
     @GetMapping(path = "/pin")
     String pinNumber(@RequestParam("phoneNumber") String phoneNumber, @RequestHeader("Session-Id") String sessionId);
 
+    @PostMapping(path = "/pin", consumes = MediaType.APPLICATION_JSON_VALUE)
+    String pinNumberPost(
+            @RequestHeader("Session-Id") String sessionId,
+            @RequestBody PhonePin phonePin);
+
     @PostMapping(
             value = "/invite/bilingual",
             headers = {
@@ -130,5 +136,10 @@ public interface BusinessServiceApi {
     @GetMapping(path = "/pin/bilingual")
     String pinNumberBilingual(@RequestParam("phoneNumber") String phoneNumber,
                               @RequestHeader("Session-Id") String sessionId);
+
+    @PostMapping(path = "/pin/bilingual", consumes = MediaType.APPLICATION_JSON_VALUE)
+    String pinNumberBilingualPost(
+            @RequestHeader("Session-Id") String sessionId,
+            @RequestBody PhonePin phonePin);
 
 }

--- a/src/main/java/uk/gov/hmcts/probate/controller/InvitationController.java
+++ b/src/main/java/uk/gov/hmcts/probate/controller/InvitationController.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.probate.controller;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.validation.BindingResult;
@@ -8,6 +9,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.probate.model.exception.PhonePinException;
 import uk.gov.hmcts.probate.service.BusinessService;
@@ -19,6 +21,7 @@ import jakarta.validation.Valid;
 import java.util.List;
 
 @RestController
+@Slf4j
 public class InvitationController {
 
     protected static final String INVITE_BASEURL = "/invite";
@@ -96,6 +99,17 @@ public class InvitationController {
         return InvitationsResult.builder().invitations(businessService.getAllInviteData(formdataId)).build();
     }
 
+    //
+    // The below should be removed ASAP but need to exist to provide a bridge during deployment
+    //
+    @GetMapping(path = INVITE_PIN_URL)
+    public String invitePin(@RequestParam("phoneNumber") String phoneNumber,
+                            @RequestHeader("Session-Id") String sessionId) {
+        log.warn("using unsafe GET for /invite/pin");
+        final PhonePin phonePin = new PhonePin(phoneNumber);
+        return businessService.getPinNumber(phonePin, sessionId, Boolean.FALSE);
+    }
+
     @PostMapping(path = INVITE_PIN_URL)
     public String invitePinPost(
             @RequestHeader("Session-Id") final String sessionId,
@@ -105,6 +119,17 @@ public class InvitationController {
             throw new PhonePinException("PhonePin did not validate", bindingResult.getFieldErrors());
         }
         return businessService.getPinNumber(phonePin, sessionId, Boolean.FALSE);
+    }
+
+    //
+    // The below should be removed ASAP but need to exist to provide a bridge during deployment
+    //
+    @GetMapping(path = INVITE_PIN_BILINGUAL_URL)
+    public String invitePinBilingual(@RequestParam("phoneNumber") String phoneNumber,
+                                     @RequestHeader("Session-Id") String sessionId) {
+        log.warn("using unsafe GET for /invite/pin/bilingual");
+        final PhonePin phonePin = new PhonePin(phoneNumber);
+        return businessService.getPinNumber(phonePin, sessionId, Boolean.TRUE);
     }
 
     @PostMapping(path = INVITE_PIN_BILINGUAL_URL)

--- a/src/main/java/uk/gov/hmcts/probate/controller/InvitationController.java
+++ b/src/main/java/uk/gov/hmcts/probate/controller/InvitationController.java
@@ -8,7 +8,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.probate.model.exception.PhonePinException;
 import uk.gov.hmcts.probate.service.BusinessService;
@@ -95,18 +94,6 @@ public class InvitationController {
     @GetMapping(path = INVITES_BASEURL + "/{formdataId}", produces = MediaType.APPLICATION_JSON_VALUE)
     public InvitationsResult getAllInviteData(@PathVariable String formdataId) {
         return InvitationsResult.builder().invitations(businessService.getAllInviteData(formdataId)).build();
-    }
-
-    @GetMapping(path = INVITE_PIN_URL)
-    public String invitePin(@RequestParam("phoneNumber") String phoneNumber,
-                            @RequestHeader("Session-Id") String sessionId) {
-        return businessService.getPinNumber(new PhonePin(phoneNumber), sessionId, Boolean.FALSE);
-    }
-
-    @GetMapping(path = INVITE_PIN_BILINGUAL_URL)
-    public String invitePinBilingual(@RequestParam("phoneNumber") String phoneNumber,
-                                     @RequestHeader("Session-Id") String sessionId) {
-        return businessService.getPinNumber(new PhonePin(phoneNumber), sessionId, Boolean.TRUE);
     }
 
     @PostMapping(path = INVITE_PIN_URL)

--- a/src/main/java/uk/gov/hmcts/probate/controller/InvitationController.java
+++ b/src/main/java/uk/gov/hmcts/probate/controller/InvitationController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import uk.gov.hmcts.probate.model.exception.PhonePinException;
 import uk.gov.hmcts.probate.service.BusinessService;
 import uk.gov.hmcts.reform.probate.model.PhonePin;
 import uk.gov.hmcts.reform.probate.model.multiapplicant.Invitation;
@@ -113,7 +114,9 @@ public class InvitationController {
             @RequestHeader("Session-Id") final String sessionId,
             @Valid @RequestBody final PhonePin phonePin,
             final BindingResult bindingResult) {
-
+        if (bindingResult.hasErrors()) {
+            throw new PhonePinException("PhonePin did not validate", bindingResult.getFieldErrors());
+        }
         return businessService.getPinNumber(phonePin, sessionId, Boolean.FALSE);
     }
 
@@ -122,6 +125,9 @@ public class InvitationController {
             @RequestHeader("Session-Id") final String sessionId,
             @Valid @RequestBody final PhonePin phonePin,
             final BindingResult bindingResult) {
+        if (bindingResult.hasErrors()) {
+            throw new PhonePinException("PhonePin did not validate", bindingResult.getFieldErrors());
+        }
         return businessService.getPinNumber(phonePin, sessionId, Boolean.TRUE);
     }
 

--- a/src/main/java/uk/gov/hmcts/probate/controller/InvitationController.java
+++ b/src/main/java/uk/gov/hmcts/probate/controller/InvitationController.java
@@ -2,6 +2,7 @@ package uk.gov.hmcts.probate.controller;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -98,27 +99,30 @@ public class InvitationController {
     @GetMapping(path = INVITE_PIN_URL)
     public String invitePin(@RequestParam("phoneNumber") String phoneNumber,
                             @RequestHeader("Session-Id") String sessionId) {
-        return businessService.getPinNumber(phoneNumber, sessionId, Boolean.FALSE);
+        return businessService.getPinNumber(new PhonePin(phoneNumber), sessionId, Boolean.FALSE);
     }
 
     @GetMapping(path = INVITE_PIN_BILINGUAL_URL)
     public String invitePinBilingual(@RequestParam("phoneNumber") String phoneNumber,
                                      @RequestHeader("Session-Id") String sessionId) {
-        return businessService.getPinNumber(phoneNumber, sessionId, Boolean.TRUE);
+        return businessService.getPinNumber(new PhonePin(phoneNumber), sessionId, Boolean.TRUE);
     }
 
     @PostMapping(path = INVITE_PIN_URL)
     public String invitePinPost(
             @RequestHeader("Session-Id") final String sessionId,
-            @RequestBody final PhonePin phonePin) {
-        return businessService.getPinNumber(phonePin.phoneNumber, sessionId, Boolean.FALSE);
+            @Valid @RequestBody final PhonePin phonePin,
+            final BindingResult bindingResult) {
+
+        return businessService.getPinNumber(phonePin, sessionId, Boolean.FALSE);
     }
 
     @PostMapping(path = INVITE_PIN_BILINGUAL_URL)
     public String invitePinBilingualPost(
             @RequestHeader("Session-Id") final String sessionId,
-            @RequestBody final PhonePin phonePin) {
-        return businessService.getPinNumber(phonePin.phoneNumber, sessionId, Boolean.TRUE);
+            @Valid @RequestBody final PhonePin phonePin,
+            final BindingResult bindingResult) {
+        return businessService.getPinNumber(phonePin, sessionId, Boolean.TRUE);
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/probate/controller/InvitationController.java
+++ b/src/main/java/uk/gov/hmcts/probate/controller/InvitationController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.probate.service.BusinessService;
+import uk.gov.hmcts.reform.probate.model.PhonePin;
 import uk.gov.hmcts.reform.probate.model.multiapplicant.Invitation;
 import uk.gov.hmcts.reform.probate.model.multiapplicant.InvitationsResult;
 
@@ -106,5 +107,18 @@ public class InvitationController {
         return businessService.getPinNumber(phoneNumber, sessionId, Boolean.TRUE);
     }
 
+    @PostMapping(path = INVITE_PIN_URL)
+    public String invitePinPost(
+            @RequestHeader("Session-Id") final String sessionId,
+            @RequestBody final PhonePin phonePin) {
+        return businessService.getPinNumber(phonePin.phoneNumber, sessionId, Boolean.FALSE);
+    }
+
+    @PostMapping(path = INVITE_PIN_BILINGUAL_URL)
+    public String invitePinBilingualPost(
+            @RequestHeader("Session-Id") final String sessionId,
+            @RequestBody final PhonePin phonePin) {
+        return businessService.getPinNumber(phonePin.phoneNumber, sessionId, Boolean.TRUE);
+    }
 
 }

--- a/src/main/java/uk/gov/hmcts/probate/controller/PinExceptionHandler.java
+++ b/src/main/java/uk/gov/hmcts/probate/controller/PinExceptionHandler.java
@@ -1,0 +1,31 @@
+package uk.gov.hmcts.probate.controller;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+import uk.gov.hmcts.probate.model.exception.PhonePinException;
+import uk.gov.hmcts.reform.probate.model.client.ErrorResponse;
+
+@Slf4j
+@ControllerAdvice
+@ResponseBody
+public class PinExceptionHandler {
+    public static final String PHONE_PIN_EXCEPTION = "PhonePin Error";
+
+    @ExceptionHandler(PhonePinException.class)
+    public ResponseEntity<ErrorResponse> handle(PhonePinException exception) {
+        log.warn("PhonePin exception: {}", exception.getMessage(), exception);
+
+        ErrorResponse errorResponse = exception.getErrorResponse();
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        return ResponseEntity.badRequest()
+                .headers(headers)
+                .body(errorResponse);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/probate/core/service/BusinessServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/probate/core/service/BusinessServiceImpl.java
@@ -7,6 +7,7 @@ import uk.gov.hmcts.probate.client.business.BusinessServiceApi;
 import uk.gov.hmcts.probate.client.submit.SubmitServiceApi;
 import uk.gov.hmcts.probate.core.service.mapper.ExecutorApplyingToInvitationMapper;
 import uk.gov.hmcts.probate.service.BusinessService;
+import uk.gov.hmcts.reform.probate.model.PhonePin;
 import uk.gov.hmcts.reform.probate.model.ProbateType;
 import uk.gov.hmcts.reform.probate.model.cases.CaseType;
 import uk.gov.hmcts.reform.probate.model.cases.CollectionMember;
@@ -320,12 +321,12 @@ public class BusinessServiceImpl implements BusinessService {
 
 
     @Override
-    public String getPinNumber(String phoneNumber, String sessionId, Boolean isBilingual) {
+    public String getPinNumber(PhonePin phonePin, String sessionId, Boolean isBilingual) {
         log.info("Get PIN number");
         if (isBilingual) {
-            return businessServiceApi.pinNumberBilingual(phoneNumber, sessionId);
+            return businessServiceApi.pinNumberBilingualPost(sessionId, phonePin);
         } else {
-            return businessServiceApi.pinNumber(phoneNumber, sessionId);
+            return businessServiceApi.pinNumberPost(sessionId, phonePin);
         }
     }
 

--- a/src/main/java/uk/gov/hmcts/probate/model/exception/PhonePinException.java
+++ b/src/main/java/uk/gov/hmcts/probate/model/exception/PhonePinException.java
@@ -1,0 +1,32 @@
+package uk.gov.hmcts.probate.model.exception;
+
+import org.springframework.validation.FieldError;
+import uk.gov.hmcts.reform.probate.model.client.ErrorResponse;
+import uk.gov.hmcts.reform.probate.model.client.ValidationError;
+import uk.gov.hmcts.reform.probate.model.client.ValidationErrorResponse;
+
+import java.util.List;
+import java.util.function.Function;
+
+public class PhonePinException extends RuntimeException {
+    private final List<FieldError> fieldErrors;
+
+    public PhonePinException(
+            final String message,
+            final List<FieldError> fieldErrors) {
+        super(message);
+        this.fieldErrors = fieldErrors;
+    }
+
+    public ErrorResponse getErrorResponse() {
+        final Function<FieldError, ValidationError> convert = fE -> ValidationError.builder()
+                .field(fE.getField())
+                .code(fE.getCode())
+                .message(fE.getDefaultMessage())
+                .build();
+        final var validationList = fieldErrors.stream()
+                .map(convert)
+                .toList();
+        return new ValidationErrorResponse(validationList);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/probate/service/BusinessService.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/BusinessService.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.probate.service;
 
+import uk.gov.hmcts.reform.probate.model.PhonePin;
 import uk.gov.hmcts.reform.probate.model.documents.BulkScanCoverSheet;
 import uk.gov.hmcts.reform.probate.model.documents.CheckAnswersSummary;
 import uk.gov.hmcts.reform.probate.model.documents.LegalDeclaration;
@@ -33,7 +34,7 @@ public interface BusinessService {
 
     List<Invitation> getAllInviteData(String formdataId);
 
-    String getPinNumber(String phoneNumber, String sessionId, Boolean isBilingual);
+    String getPinNumber(PhonePin phonePin, String sessionId, Boolean isBilingual);
 
     List<Invitation> sendInvitations(List<Invitation> invitations, String sessionId, Boolean isBilingual);
 

--- a/src/test/java/uk/gov/hmcts/probate/core/service/BusinessServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/core/service/BusinessServiceImplTest.java
@@ -12,6 +12,7 @@ import uk.gov.hmcts.probate.TestUtils;
 import uk.gov.hmcts.probate.client.business.BusinessServiceApi;
 import uk.gov.hmcts.probate.client.submit.SubmitServiceApi;
 import uk.gov.hmcts.probate.core.service.mapper.ExecutorApplyingToInvitationMapper;
+import uk.gov.hmcts.reform.probate.model.PhonePin;
 import uk.gov.hmcts.reform.probate.model.ProbateType;
 import uk.gov.hmcts.reform.probate.model.cases.CaseInfo;
 import uk.gov.hmcts.reform.probate.model.cases.CaseType;
@@ -36,6 +37,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -523,12 +525,13 @@ public class BusinessServiceImplTest {
 
     @Test
     public void shouldGetPinNumber() {
+        final PhonePin phonePin = new PhonePin(phoneNumber);
 
-        businessService.getPinNumber(phoneNumber, sessionId, Boolean.FALSE);
-        verify(businessServiceApi).pinNumber(phoneNumber, sessionId);
+        businessService.getPinNumber(phonePin, sessionId, Boolean.FALSE);
+        verify(businessServiceApi).pinNumberPost(eq(sessionId), eq(phonePin));
 
-        businessService.getPinNumber(phoneNumber, sessionId, Boolean.TRUE);
-        verify(businessServiceApi).pinNumberBilingual(phoneNumber, sessionId);
+        businessService.getPinNumber(phonePin, sessionId, Boolean.TRUE);
+        verify(businessServiceApi).pinNumberBilingualPost(eq(sessionId), eq(phonePin));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/probate/core/service/BusinessServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/core/service/BusinessServiceImplTest.java
@@ -37,7 +37,6 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -528,10 +527,10 @@ public class BusinessServiceImplTest {
         final PhonePin phonePin = new PhonePin(phoneNumber);
 
         businessService.getPinNumber(phonePin, sessionId, Boolean.FALSE);
-        verify(businessServiceApi).pinNumberPost(eq(sessionId), eq(phonePin));
+        verify(businessServiceApi).pinNumberPost(sessionId, phonePin);
 
         businessService.getPinNumber(phonePin, sessionId, Boolean.TRUE);
-        verify(businessServiceApi).pinNumberBilingualPost(eq(sessionId), eq(phonePin));
+        verify(businessServiceApi).pinNumberBilingualPost(sessionId, phonePin);
     }
 
     @Test


### PR DESCRIPTION
### Jira link

<!-- 
Replace PROJ-XXXXXX with your Jira key
Remove this section if its not applicable, or replace it with another reference link
-->
See [DTSPB-4664](https://tools.hmcts.net/jira/browse/DTSPB-4664)

### Change description
Converts the GET calls to the business-service for sending PINs to POSTs so we can send the payload in the body which does not then get logged.

Also converts the exposed GET calls here to POSTs for the same reason.

Relies on changes in https://github.com/hmcts/probate-commons/pull/256 and https://github.com/hmcts/probate-business-service/pull/1041

### Testing done

Tested in preview environment

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
