### PR TITLE
DTSPB-2859 Remove old cron scheduling which will now be managed in k8s

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -161,6 +161,7 @@ tasks.withType(Test) {
 
 def versions = [
         authCheckerLib                  : '3.1.1',
+        commonsBeanutils                : '1.11.0',
         commonsIO                       : '2.19.0',
         commonMark                      : '0.17.0',
         feign                           : '13.5',
@@ -312,6 +313,13 @@ dependencies {
     contractTestImplementation sourceSets.main.runtimeClasspath
     contractTestImplementation sourceSets.test.runtimeClasspath
     contractTestImplementation group: 'io.github.openfeign', name: 'feign-core', version: versions.feign
+
+    constraints {
+        checkstyle group: 'commons-beanutils', name: 'commons-beanutils', version: versions.commonsBeanutils
+        implementation group: 'commons-beanutils', name: 'commons-beanutils', version: versions.commonsBeanutils
+        testFunctionalImplementation group: 'commons-beanutils', name: 'commons-beanutils', version: versions.commonsBeanutils
+        testIntegrationImplementation group: 'commons-beanutils', name: 'commons-beanutils', version: versions.commonsBeanutils
+    }
 }
 
 task fortifyScan(type: JavaExec)  {

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd ">
-    <suppress>
+    <suppress until = "2025-10-15">
         <!--
           Pebble literal templates can permit loading from the filesystem.
           If a user could control the template input this would be an issue,
@@ -9,5 +9,13 @@
           in probate-commons.
         -->
         <cve>CVE-2025-1686</cve>
+    </suppress>
+    <suppress until = "2025-10-15">
+        <!--
+            The direct dependencies on commons-beanutils have been coerced
+            into using an updated version but sonar-plugin-api bundles its
+            own affected version.
+        -->
+        <cve>CVE-2025-48734</cve>
     </suppress>
 </suppressions>

--- a/src/main/java/uk/gov/hmcts/probate/controller/DataExtractController.java
+++ b/src/main/java/uk/gov/hmcts/probate/controller/DataExtractController.java
@@ -6,7 +6,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -50,7 +49,6 @@ public class DataExtractController {
         return dataExtractService.initiateHmrcExtract(fromDate, toDate);
     }
 
-    @Scheduled(cron = "${cron.ironMountain.schedule}")
     @Operation(summary = "Initiate IronMountain data extract", description = "Will find cases for yesterdays date")
     @PostMapping(path = "/iron-mountain")
     public ResponseEntity initiateIronMountainExtract() {
@@ -67,7 +65,6 @@ public class DataExtractController {
         return dataExtractService.initiateIronMountainExtract(date);
     }
 
-    @Scheduled(cron = "${cron.exela.schedule}")
     @Operation(summary = "Initiate Excela data extract", description = "Will find cases for yesterdays date")
     @PostMapping(path = "/exela")
     public ResponseEntity initiateExelaExtract() {

--- a/src/main/java/uk/gov/hmcts/probate/controller/GrantController.java
+++ b/src/main/java/uk/gov/hmcts/probate/controller/GrantController.java
@@ -4,7 +4,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -26,7 +25,6 @@ public class GrantController {
     private final GrantDelayedNotifier grantDelayedNotifier;
     private final GrantAwaitingDocumentsNotifier grantAwaitingDocumentsNotifier;
 
-    @Scheduled(cron = "${cron.grantDelayed.schedule}")
     @Operation(summary = "Notify grants delayed")
     @PostMapping(path = "/delay-notification")
     public ResponseEntity initiateGrantDelayedSchedule() {
@@ -40,7 +38,6 @@ public class GrantController {
         return ResponseEntity.ok("Perform grant delayed notification called");
     }
 
-    @Scheduled(cron = "${cron.grantAwaitingDocuments.schedule}")
     @Operation(summary = "Notify grants Awaiting Documents")
     @PostMapping(path = "/awaiting-documents-notification")
     public ResponseEntity initiateAwaitingDocumentsSchedule() {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -83,13 +83,5 @@ feign:
         loggerLevel: basic
 
 cron:
-  ironMountain:
-    schedule: "0 5 2 * * *"
-  exela:
-    schedule: "0 10 2 * * *"
-  grantDelayed:
-    schedule: "0 15 2 * * *"
-  grantAwaitingDocuments:
-    schedule: "0 20 2 31 2 *"
   caveatExpiry:
     schedule: "0 0 3 * * *"


### PR DESCRIPTION
### Jira link

See [DTSPB-2859](https://tools.hmcts.net/jira/browse/DTSPB-2859)

### Change description
Removes the `@Scheduled` Spring annotations and the configuration for them. IronMountain / Exela will be managed using k8s cronjobs in back-office, the grant tasks have not successfully run in over a year so we are removing them as new notification changes will replace them.

### Testing done

Tested within the demo environment.

### Checklist

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
