### PR TITLE
DTSPB-2859 Add feature flag to switch orch->back-office

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -16,7 +16,9 @@ def secrets = [
         secret('probateIdamOauthRedirectUrl', 'IDAM_OAUTH2_REDIRECT_URI'),
         secret('probate-service-id', 'IDAM_CLIENT_ID'),
         secret('cwUserEmail', 'CW_USER_EMAIL'),
-        secret('cwUserPass', 'CW_USER_PASSWORD')
+        secret('cwUserPass', 'CW_USER_PASSWORD'),
+        secret('launchdarkly-key', 'LAUNCHDARKLY_KEY'),
+        secret('launchdarklyUserkeyBackend', 'LD_USER_KEY'),
 ]]
 
 static LinkedHashMap<String, Object> secret(String secretName, String envVar) {

--- a/build.gradle
+++ b/build.gradle
@@ -249,6 +249,8 @@ dependencies {
     implementation group: 'org.mapstruct', name: 'mapstruct-processor', version: versions.mapStruct
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: versions.jacksonDatabind
     implementation group: 'net.logstash.logback', name: 'logstash-logback-encoder', version: '8.1'
+    implementation group: 'com.launchdarkly', name: 'launchdarkly-java-server-sdk', version: '7.9.0'
+
     annotationProcessor group: 'org.projectlombok', name: 'lombok', version: versions.lombok
     annotationProcessor group: 'org.mapstruct', name: 'mapstruct-processor', version: versions.mapStruct
 

--- a/charts/probate-orchestrator-service/Chart.yaml
+++ b/charts/probate-orchestrator-service/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: probate-orchestrator-service
 home: https://github.com/hmcts/probate-orchestrator-service
-version: 1.0.49
+version: 1.0.50
 description: HMCTS Probate Orchestrator Service
 maintainers:
   - name: HMCTS Probate Team

--- a/charts/probate-orchestrator-service/values.preview.template.yaml
+++ b/charts/probate-orchestrator-service/values.preview.template.yaml
@@ -3,3 +3,11 @@ java:
     LOG_LEVEL: DEBUG
   image: ${IMAGE_NAME}
   ingressHost: ${SERVICE_NAME}.preview.platform.hmcts.net
+
+keyVaults:
+  probate:
+    secrets:
+      - name: launchdarkly-key
+        alias: ld.sdk_key
+      - name: launchdarklyUserkeyBackend
+        alias: ld.user.key

--- a/charts/probate-orchestrator-service/values.yaml
+++ b/charts/probate-orchestrator-service/values.yaml
@@ -51,3 +51,7 @@ java:
           alias: SCHEDULER_CASEWORKER_USERNAME
         - name: schedulerCaseWorkerPass
           alias: SCHEDULER_CASEWORKER_PASSWORD
+        - name: launchdarkly-key
+          alias: ld.sdk_key
+        - name: launchdarklyUserkeyBackend
+          alias: ld.user.key

--- a/src/main/java/uk/gov/hmcts/probate/configuration/LDClientConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/probate/configuration/LDClientConfiguration.java
@@ -1,0 +1,15 @@
+package uk.gov.hmcts.probate.configuration;
+
+import com.launchdarkly.sdk.server.LDClient;
+import com.launchdarkly.sdk.server.interfaces.LDClientInterface;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class LDClientConfiguration {
+    @Bean
+    public LDClientInterface ldClient(@Value("${ld.sdk_key}") String ldSdkKey) {
+        return new LDClient(ldSdkKey);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/probate/controller/DataExtractController.java
+++ b/src/main/java/uk/gov/hmcts/probate/controller/DataExtractController.java
@@ -1,9 +1,8 @@
 package uk.gov.hmcts.probate.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import io.swagger.v3.oas.annotations.Operation;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -12,12 +11,12 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import uk.gov.hmcts.probate.service.DataExtractService;
+import uk.gov.hmcts.probate.service.FeatureToggleService;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 
 @Slf4j
-@RequiredArgsConstructor
 @RequestMapping("/data-extract")
 @RestController
 @Tag(name = "Initiate data extract for HMRC, IronMountain and Excela")
@@ -25,6 +24,14 @@ public class DataExtractController {
 
     private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd");
     private final DataExtractService dataExtractService;
+    private final FeatureToggleService featureToggleService;
+
+    public DataExtractController(
+            final DataExtractService dataExtractService,
+            final FeatureToggleService featureToggleService) {
+        this.dataExtractService = dataExtractService;
+        this.featureToggleService = featureToggleService;
+    }
 
     @Operation(summary = "Initiate HMRC data extract", description = "Will find cases for yesterdays date")
     @PostMapping(path = "/hmrc")
@@ -54,6 +61,10 @@ public class DataExtractController {
     @Operation(summary = "Initiate IronMountain data extract", description = "Will find cases for yesterdays date")
     @PostMapping(path = "/iron-mountain")
     public ResponseEntity initiateIronMountainExtract() {
+        if (featureToggleService.isIronMountainInBackOffice()) {
+            log.info("IronMountain extract task is feature toggled to run through back office");
+            return ResponseEntity.internalServerError().body("Iron Mountain extract task is run through back office");
+        }
 
         return initiateIronMountainExtract(DATE_FORMAT.format(LocalDate.now().minusDays(1L)));
     }
@@ -71,6 +82,10 @@ public class DataExtractController {
     @Operation(summary = "Initiate Excela data extract", description = "Will find cases for yesterdays date")
     @PostMapping(path = "/exela")
     public ResponseEntity initiateExelaExtract() {
+        if (featureToggleService.isExelaInBackOffice()) {
+            log.info("Exela extract task is feature toggled to run through back office");
+            return ResponseEntity.internalServerError().body("Exela extract task is run through back office");
+        }
         log.info("Extract initiated for Excela");
         return initiateExelaExtract(DATE_FORMAT.format(LocalDate.now().minusDays(1L)));
     }
@@ -87,9 +102,9 @@ public class DataExtractController {
     @Operation(summary = "Initiate Excela data extract", description = " Date MUST be in format 'yyyy-MM-dd'")
     @PostMapping(path = "/exela/{fromDate}/{toDate}")
     public ResponseEntity initiateExelaExtractDateRange(
-        @Parameter(name = "Date range to find cases against", required = true)
-        @PathVariable("fromDate") String fromDate,
-        @PathVariable("toDate") String toDate) {
+            @Parameter(name = "Date range to find cases against", required = true)
+            @PathVariable("fromDate") String fromDate,
+            @PathVariable("toDate") String toDate) {
 
         log.info("Calling perform Excela data extract from date...");
         return dataExtractService.initiateExelaExtractDateRange(fromDate, toDate);
@@ -98,9 +113,9 @@ public class DataExtractController {
     @Operation(summary = "Initiate Smee and Ford data extract", description = " Date MUST be in format 'yyyy-MM-dd'")
     @PostMapping(path = "/smee-and-ford/{fromDate}/{toDate}")
     public ResponseEntity initiateSmeeAndFordExtractDateRange(
-        @Parameter(name = "Date range to find cases against", required = true)
-        @PathVariable("fromDate") String fromDate,
-        @PathVariable("toDate") String toDate) {
+            @Parameter(name = "Date range to find cases against", required = true)
+            @PathVariable("fromDate") String fromDate,
+            @PathVariable("toDate") String toDate) {
 
         log.info("Calling perform Smee And Ford data extract from date, to date {} {}", fromDate, toDate);
         return dataExtractService.initiateSmeeAndFordExtractDateRange(fromDate, toDate);

--- a/src/main/java/uk/gov/hmcts/probate/core/service/FeatureToggleServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/probate/core/service/FeatureToggleServiceImpl.java
@@ -1,0 +1,57 @@
+package uk.gov.hmcts.probate.core.service;
+
+import com.launchdarkly.sdk.LDContext;
+import com.launchdarkly.sdk.server.interfaces.LDClientInterface;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.probate.service.FeatureToggleService;
+
+@Slf4j
+@Service
+public class FeatureToggleServiceImpl implements FeatureToggleService {
+    private final LDClientInterface ldClient;
+    private final LDContext ldContext;
+
+    public static final String IRON_MOUNTAIN_IN_BACK_OFFICE = "probate-iron-mountain-in-back-office";
+    public static final String EXELA_IN_BACK_OFFICE = "probate-exela-in-back-office";
+
+    @Autowired
+    public FeatureToggleServiceImpl(
+            final LDClientInterface ldClient,
+            @Value("${ld.user.key}") final String ldUserKey,
+            @Value("${ld.user.firstName}") final String ldUserFirstName,
+            @Value("${ld.user.lastName}") final String ldUserLastName) {
+
+        final String contextName = new StringBuilder()
+                .append(ldUserFirstName)
+                .append(" ")
+                .append(ldUserLastName)
+                .toString();
+
+        this.ldClient = ldClient;
+        this.ldContext = LDContext.builder(ldUserKey + "_orchestrator_service")
+                .name(contextName)
+                .kind("application")
+                .set("timestamp", String.valueOf(System.currentTimeMillis()))
+                .build();
+    }
+
+    private boolean isFeatureToggleOn(
+            final String featureToggleCode,
+            final boolean defaultValue) {
+        return this.ldClient.boolVariation(featureToggleCode, this.ldContext, defaultValue);
+    }
+
+
+    @Override
+    public boolean isIronMountainInBackOffice() {
+        return this.isFeatureToggleOn(IRON_MOUNTAIN_IN_BACK_OFFICE, false);
+    }
+
+    @Override
+    public boolean isExelaInBackOffice() {
+        return this.isFeatureToggleOn(EXELA_IN_BACK_OFFICE, false);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/probate/service/FeatureToggleService.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/FeatureToggleService.java
@@ -1,0 +1,7 @@
+package uk.gov.hmcts.probate.service;
+
+public interface FeatureToggleService {
+    boolean isIronMountainInBackOffice();
+
+    boolean isExelaInBackOffice();
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -84,9 +84,9 @@ feign:
 
 cron:
   ironMountain:
-    schedule: "0 5 2 * * *"
+    schedule: "0 */5 * * * *"
   exela:
-    schedule: "0 10 2 * * *"
+    schedule: "0 */5 * * * *"
   grantDelayed:
     schedule: "0 15 2 * * *"
   grantAwaitingDocuments:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -93,3 +93,10 @@ cron:
     schedule: "0 20 2 31 2 *"
   caveatExpiry:
     schedule: "0 0 3 * * *"
+
+ld:
+  sdk_key: ${LAUNCHDARKLY_KEY:dummy}
+  user:
+    key: ${LD_USER_KEY:dummy_key}
+    firstName: Probate
+    lastName: Backend

--- a/src/test/java/uk/gov/hmcts/probate/controller/DataExtractControllerUnitTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/controller/DataExtractControllerUnitTest.java
@@ -1,27 +1,53 @@
 package uk.gov.hmcts.probate.controller;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import uk.gov.hmcts.probate.service.DataExtractService;
+import uk.gov.hmcts.probate.service.FeatureToggleService;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-@ExtendWith(SpringExtension.class)
 public class DataExtractControllerUnitTest {
 
     @Mock
     DataExtractService dataExtractService;
 
-    @InjectMocks
+    @Mock
+    FeatureToggleService featureToggleService;
+
+
     DataExtractController dataExtractController;
+
+    AutoCloseable closeableMocks;
+
+    @BeforeEach
+    void setUp() {
+        closeableMocks = MockitoAnnotations.openMocks(this);
+
+        when(featureToggleService.isIronMountainInBackOffice())
+                .thenReturn(false);
+        when(featureToggleService.isExelaInBackOffice())
+                .thenReturn(false);
+
+        dataExtractController = new DataExtractController(
+                dataExtractService,
+                featureToggleService);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        closeableMocks.close();
+    }
 
     @Test
     public void shouldInitiateSmeeAndFordDataExtractForDateRange() {
@@ -53,5 +79,29 @@ public class DataExtractControllerUnitTest {
         when(dataExtractService.initiateExelaExtractDateRange(anyString(), anyString())).thenReturn(responseEntity);
         ResponseEntity response = dataExtractController.initiateExelaExtractDateRange("2020-12-30", "2020-12-31");
         assertThat(response).isEqualTo(responseEntity);
+    }
+
+    @Test
+    void shouldNotInitiateIronMountainWhenInBackOffice() {
+        when(featureToggleService.isIronMountainInBackOffice())
+                .thenReturn(true);
+
+        ResponseEntity responseEntity = dataExtractController.initiateIronMountainExtract();
+
+        assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatusCode.valueOf(500));
+        assertThat(responseEntity.getBody()).isEqualTo("Iron Mountain extract task is run through back office");
+        verifyNoInteractions(dataExtractService);
+    }
+
+    @Test
+    void shouldNotInitiateExelaWhenInBackOffice() {
+        when(featureToggleService.isExelaInBackOffice())
+                .thenReturn(true);
+
+        ResponseEntity responseEntity = dataExtractController.initiateExelaExtract();
+
+        assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatusCode.valueOf(500));
+        assertThat(responseEntity.getBody()).isEqualTo("Exela extract task is run through back office");
+        verifyNoInteractions(dataExtractService);
     }
 }

--- a/src/test/java/uk/gov/hmcts/probate/core/service/FeatureToggleServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/core/service/FeatureToggleServiceImplTest.java
@@ -1,0 +1,104 @@
+package uk.gov.hmcts.probate.core.service;
+
+import com.launchdarkly.sdk.server.interfaces.LDClientInterface;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+public class FeatureToggleServiceImplTest {
+    @Mock
+    private LDClientInterface ldClientMock;
+
+    private FeatureToggleServiceImpl featureToggleService;
+
+    private AutoCloseable closeableMocks;
+
+    @BeforeEach
+    void setup() {
+        closeableMocks = MockitoAnnotations.openMocks(this);
+
+        featureToggleService = new FeatureToggleServiceImpl(ldClientMock, "", "", "");
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        closeableMocks.close();
+    }
+
+    @Test
+    void returnsTrueWhenIronMountainInBackOffice() {
+        when(ldClientMock.boolVariation(
+                eq(FeatureToggleServiceImpl.IRON_MOUNTAIN_IN_BACK_OFFICE),
+                any(),
+                anyBoolean()))
+                .thenReturn(true);
+
+        final boolean result = featureToggleService.isIronMountainInBackOffice();
+
+        assertTrue(result, "Expected true from client returning true");
+        verify(ldClientMock).boolVariation(
+                eq(FeatureToggleServiceImpl.IRON_MOUNTAIN_IN_BACK_OFFICE),
+                any(),
+                anyBoolean());
+        verifyNoMoreInteractions(ldClientMock);
+    }
+
+    @Test
+    void returnsFalseWhenNotIronMountainInBackOffice() {
+        when(ldClientMock.boolVariation(
+                eq(FeatureToggleServiceImpl.IRON_MOUNTAIN_IN_BACK_OFFICE),
+                any(),
+                anyBoolean()))
+                .thenReturn(false);
+
+        final boolean result = featureToggleService.isIronMountainInBackOffice();
+
+        assertFalse(result, "Expected false from client returning false");
+        verify(ldClientMock).boolVariation(
+                eq(FeatureToggleServiceImpl.IRON_MOUNTAIN_IN_BACK_OFFICE),
+                any(),
+                anyBoolean());
+        verifyNoMoreInteractions(ldClientMock);
+    }
+
+    @Test
+    void returnsTrueWhenExelaInBackOffice() {
+        when(ldClientMock.boolVariation(eq(FeatureToggleServiceImpl.EXELA_IN_BACK_OFFICE), any(), anyBoolean()))
+                .thenReturn(true);
+
+        final boolean result = featureToggleService.isExelaInBackOffice();
+
+        assertTrue(result, "Expected true from client returning true");
+        verify(ldClientMock).boolVariation(
+                eq(FeatureToggleServiceImpl.EXELA_IN_BACK_OFFICE),
+                any(),
+                anyBoolean());
+        verifyNoMoreInteractions(ldClientMock);
+    }
+
+    @Test
+    void returnsFalseWhenNotExelaInBackOffice() {
+        when(ldClientMock.boolVariation(eq(FeatureToggleServiceImpl.EXELA_IN_BACK_OFFICE), any(), anyBoolean()))
+                .thenReturn(false);
+
+        final boolean result = featureToggleService.isExelaInBackOffice();
+
+        assertFalse(result, "Expected false from client returning false");
+        verify(ldClientMock).boolVariation(
+                eq(FeatureToggleServiceImpl.EXELA_IN_BACK_OFFICE),
+                any(),
+                anyBoolean());
+        verifyNoMoreInteractions(ldClientMock);
+    }
+}


### PR DESCRIPTION
### Jira link
See [DTSPB-2859](https://tools.hmcts.net/jira/browse/DTSPB-2859)

### Change description
adds a FeatureToggleService which can then be used to automatically disable the currently existing `@Scheduled` tasks in orchestrator. this means we can have both changes deplyed with the appropriate config but only actually use one (and switch without making a deployment change.

the one problem i can forsee is if anything is actually calling these endpoints they will now get failures reported but to the best of my knowledge nothing is actually doing that.

### Testing done
When deployed in preview with a 5 min time interval between runs and toggling the setting:
```
2025-Jun-05 09:45:00.005 INFO  [scheduling-1] u.g.h.p.c.DataExtractController - Extract initiated for Excela
2025-Jun-05 09:45:00.005 INFO  [scheduling-1] u.g.h.p.c.DataExtractController - Calling perform Excela data extract from date...
2025-Jun-05 09:45:00.005 INFO  [scheduling-1] u.g.h.p.c.DataExtractController - Calling perform Excela data extract from date...
2025-Jun-05 09:45:00.005 INFO  [scheduling-1] u.g.h.p.c.s.DataExtractServiceImpl - Calling perform Exela data extract from date...
2025-Jun-05 09:45:00.006 INFO  [scheduling-1] u.g.h.p.c.s.DataExtractServiceImpl - Perform Exela data extract from date finished
2025-Jun-05 09:45:00.006 INFO  [pool-26-thread-1] u.g.h.p.c.s.DataExtractServiceImpl - Perform Exela data extract from date started
2025-Jun-05 09:45:00.006 INFO  [pool-26-thread-1] u.g.h.p.c.s.SecurityUtils - Using cached Scheduler IDAM token.
2025-Jun-05 09:45:00.006 INFO  [pool-26-thread-1] u.g.h.p.c.s.SecurityUtils - Getting AccessToken...
2025-Jun-05 09:45:00.006 INFO  [pool-26-thread-1] u.g.h.p.c.s.BackOfficeServiceImpl - Calling BackOfficeAPI to initiateExelaExtract as scheduler
2025-Jun-05 09:45:00.007 INFO  [scheduling-1] u.g.h.p.c.DataExtractController - Calling perform Iron Mountain data extract from date...
2025-Jun-05 09:45:00.007 INFO  [scheduling-1] u.g.h.p.c.s.DataExtractServiceImpl - Calling perform Iron Mountain data extract from date...
2025-Jun-05 09:45:00.007 INFO  [scheduling-1] u.g.h.p.c.s.DataExtractServiceImpl - Perform Iron Mountain data extract from date finished
2025-Jun-05 09:45:00.007 INFO  [pool-27-thread-1] u.g.h.p.c.s.DataExtractServiceImpl - Perform Iron Mountain data extract from date started
2025-Jun-05 09:45:00.007 INFO  [pool-27-thread-1] u.g.h.p.c.s.SecurityUtils - Using cached Scheduler IDAM token.
2025-Jun-05 09:45:00.007 INFO  [pool-27-thread-1] u.g.h.p.c.s.SecurityUtils - Getting AccessToken...
2025-Jun-05 09:45:00.007 INFO  [pool-27-thread-1] u.g.h.p.c.s.BackOfficeServiceImpl - Calling BackOfficeAPI to initiateIronMountainExtract as scheduler
2025-Jun-05 09:50:00.000 INFO  [scheduling-1] u.g.h.p.c.DataExtractController - IronMountain extract task is feature toggled to run through back office
2025-Jun-05 09:50:00.001 INFO  [scheduling-1] u.g.h.p.c.DataExtractController - Exela extract task is feature toggled to run through back office
```

### Security Vulnerability Assessment ###
**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
