### PR TITLE
DTSPB-5046 use feature toggle to control whether search for caveat from ccd or es

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -16,7 +16,9 @@ def secrets = [
         secret('probateIdamOauthRedirectUrl', 'IDAM_OAUTH2_REDIRECT_URI'),
         secret('probate-service-id', 'IDAM_CLIENT_ID'),
         secret('cwUserEmail', 'CW_USER_EMAIL'),
-        secret('cwUserPass', 'CW_USER_PASSWORD')
+        secret('cwUserPass', 'CW_USER_PASSWORD'),
+        secret('launchdarkly-key', 'LAUNCHDARKLY_KEY'),
+        secret('launchdarklyUserkeyBackend', 'LD_USER_KEY')
 ]]
 
 static LinkedHashMap<String, Object> secret(String secretName, String envVar) {

--- a/build.gradle
+++ b/build.gradle
@@ -259,6 +259,7 @@ dependencies {
     implementation group: 'org.mapstruct', name: 'mapstruct-processor', version: versions.mapStruct
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: versions.jacksonDatabind
     implementation group: 'net.logstash.logback', name: 'logstash-logback-encoder', version: '9.0'
+    implementation group: 'com.launchdarkly', name: 'launchdarkly-java-server-sdk', version: '7.10.2'
     annotationProcessor group: 'org.projectlombok', name: 'lombok', version: versions.lombok
     annotationProcessor group: 'org.mapstruct', name: 'mapstruct-processor', version: versions.mapStruct
 

--- a/charts/probate-orchestrator-service/Chart.yaml
+++ b/charts/probate-orchestrator-service/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: probate-orchestrator-service
 home: https://github.com/hmcts/probate-orchestrator-service
-version: 1.0.51
+version: 1.0.52
 description: HMCTS Probate Orchestrator Service
 maintainers:
   - name: HMCTS Probate Team

--- a/charts/probate-orchestrator-service/values.preview.template.yaml
+++ b/charts/probate-orchestrator-service/values.preview.template.yaml
@@ -3,3 +3,11 @@ java:
     LOG_LEVEL: DEBUG
   image: ${IMAGE_NAME}
   ingressHost: ${SERVICE_NAME}.preview.platform.hmcts.net
+
+keyVaults:
+  probate:
+    secrets:
+      - name: launchdarkly-key
+        alias: ld.sdk_key
+      - name: launchdarklyUserkeyBackend
+        alias: ld.user.key

--- a/charts/probate-orchestrator-service/values.yaml
+++ b/charts/probate-orchestrator-service/values.yaml
@@ -51,3 +51,7 @@ java:
           alias: SCHEDULER_CASEWORKER_USERNAME
         - name: schedulerCaseWorkerPass
           alias: SCHEDULER_CASEWORKER_PASSWORD
+        - name: launchdarkly-key
+          alias: ld.sdk_key
+        - name: launchdarklyUserkeyBackend
+          alias: ld.user.key

--- a/src/main/java/uk/gov/hmcts/probate/configuration/LDClientConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/probate/configuration/LDClientConfiguration.java
@@ -1,0 +1,34 @@
+package uk.gov.hmcts.probate.configuration;
+
+import com.launchdarkly.sdk.LDContext;
+import com.launchdarkly.sdk.server.LDClient;
+import com.launchdarkly.sdk.server.interfaces.LDClientInterface;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class LDClientConfiguration {
+    @Bean
+    public LDClientInterface ldClient(
+            @Value("${ld.sdk_key}") final String ldSdkKey) {
+        return new LDClient(ldSdkKey);
+    }
+
+    @Bean
+    public LDContext ldContext(
+            @Value("${ld.user.key}") final String ldUserKey,
+            @Value("${ld.user.firstName}") final String ldUserFirstName,
+            @Value("${ld.user.lastName}") final String ldUserLastName) {
+        final String contextName = new StringBuilder()
+                .append(ldUserFirstName)
+                .append(" ")
+                .append(ldUserLastName)
+                .toString();
+        return LDContext.builder(ldUserKey)
+                .name(contextName)
+                .kind("application")
+                .set("timestamp", String.valueOf(System.currentTimeMillis()))
+                .build();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/probate/core/service/FeatureToggleServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/probate/core/service/FeatureToggleServiceImpl.java
@@ -12,6 +12,8 @@ public class FeatureToggleServiceImpl implements FeatureToggleService {
     private final LDClientInterface ldClient;
     private final LDContext ldContext;
 
+    static final String PAYMENT_LOOKUP_FEATURE = "probate-use-ccd-lookup-not-elastic-when-paying";
+
     public FeatureToggleServiceImpl(
             final LDClientInterface ldClient,
             final LDContext ldContext) {
@@ -27,6 +29,6 @@ public class FeatureToggleServiceImpl implements FeatureToggleService {
 
     @Override
     public boolean useCcdLookupForPayments() {
-        return isFeatureToggleOn("probate-use-ccd-lookup-not-elastic-when-paying", false);
+        return isFeatureToggleOn(PAYMENT_LOOKUP_FEATURE, false);
     }
 }

--- a/src/main/java/uk/gov/hmcts/probate/core/service/FeatureToggleServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/probate/core/service/FeatureToggleServiceImpl.java
@@ -6,12 +6,19 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.probate.service.FeatureToggleService;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
 @Service
 @Slf4j
 public class FeatureToggleServiceImpl implements FeatureToggleService {
     private final LDClientInterface ldClient;
     private final LDContext ldContext;
 
+    private final AtomicBoolean cacheConfirmFeatureToggle;
+    private final AtomicInteger logLimit;
+
+    static final String CONFIRM_FEATURE = "probate-confirm-feature-toggle";
     static final String PAYMENT_LOOKUP_FEATURE = "probate-use-ccd-lookup-not-elastic-when-paying";
 
     public FeatureToggleServiceImpl(
@@ -19,6 +26,9 @@ public class FeatureToggleServiceImpl implements FeatureToggleService {
             final LDContext ldContext) {
         this.ldClient = ldClient;
         this.ldContext = ldContext;
+
+        this.cacheConfirmFeatureToggle = new AtomicBoolean(false);
+        this.logLimit = new AtomicInteger(0);
     }
 
     private boolean isFeatureToggleOn(
@@ -27,8 +37,21 @@ public class FeatureToggleServiceImpl implements FeatureToggleService {
         return this.ldClient.boolVariation(featureToggleCode, this.ldContext, defaultValue);
     }
 
+    void confirmFeatureToggle() {
+        final boolean confirmFeatureToggle = isFeatureToggleOn(CONFIRM_FEATURE, false);
+        final int currentLimit = logLimit.getAndIncrement();
+        if (cacheConfirmFeatureToggle.compareAndSet(!confirmFeatureToggle, confirmFeatureToggle)) {
+            log.info("confirmFeatureToggle is now {}, was previously inverted", confirmFeatureToggle);
+        } else {
+            if (currentLimit % 128 == 0) {
+                log.info("confirmFeatureToggle is {} (called {} times)", confirmFeatureToggle, currentLimit);
+            }
+        }
+    }
+
     @Override
     public boolean useCcdLookupForPayments() {
+        confirmFeatureToggle();
         return isFeatureToggleOn(PAYMENT_LOOKUP_FEATURE, false);
     }
 }

--- a/src/main/java/uk/gov/hmcts/probate/core/service/FeatureToggleServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/probate/core/service/FeatureToggleServiceImpl.java
@@ -1,0 +1,32 @@
+package uk.gov.hmcts.probate.core.service;
+
+import com.launchdarkly.sdk.LDContext;
+import com.launchdarkly.sdk.server.interfaces.LDClientInterface;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.probate.service.FeatureToggleService;
+
+@Service
+@Slf4j
+public class FeatureToggleServiceImpl implements FeatureToggleService {
+    private final LDClientInterface ldClient;
+    private final LDContext ldContext;
+
+    public FeatureToggleServiceImpl(
+            final LDClientInterface ldClient,
+            final LDContext ldContext) {
+        this.ldClient = ldClient;
+        this.ldContext = ldContext;
+    }
+
+    private boolean isFeatureToggleOn(
+            final String featureToggleCode,
+            final boolean defaultValue) {
+        return this.ldClient.boolVariation(featureToggleCode, this.ldContext, defaultValue);
+    }
+
+    @Override
+    public boolean useCcdLookupForPayments() {
+        return isFeatureToggleOn("probate-use-ccd-lookup-not-elastic-when-paying", false);
+    }
+}

--- a/src/main/java/uk/gov/hmcts/probate/service/FeatureToggleService.java
+++ b/src/main/java/uk/gov/hmcts/probate/service/FeatureToggleService.java
@@ -1,0 +1,5 @@
+package uk.gov.hmcts.probate.service;
+
+public interface FeatureToggleService {
+    boolean useCcdLookupForPayments();
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -81,3 +81,10 @@ feign:
         connectTimeout: 30000
         readTimeout: 30000
         loggerLevel: basic
+
+ld:
+  sdk_key: ${LAUNCHDARKLY_KEY:dummy}
+  user:
+    key: ${LD_USER_KEY:dummy_key}
+    firstName: Probate
+    lastName: Orchestrator

--- a/src/test/java/uk/gov/hmcts/probate/core/service/FeatureToggleServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/core/service/FeatureToggleServiceImplTest.java
@@ -57,4 +57,13 @@ class FeatureToggleServiceImplTest {
                 anyBoolean());
         assertThat(actual, equalTo(expected));
     }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void coverConfirmFeatureToggleFalse(final boolean param) {
+        when(ldClientMock.boolVariation(eq(FeatureToggleServiceImpl.CONFIRM_FEATURE), eq(ldContextMock), anyBoolean()))
+                .thenReturn(param);
+
+        featureToggleService.confirmFeatureToggle();
+    }
 }

--- a/src/test/java/uk/gov/hmcts/probate/core/service/FeatureToggleServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/core/service/FeatureToggleServiceImplTest.java
@@ -11,7 +11,6 @@ import org.mockito.MockitoAnnotations;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
@@ -44,12 +43,18 @@ class FeatureToggleServiceImplTest {
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     void lookupFromLDWhenCcdPaymentQueried(final boolean expected) {
-        when(ldClientMock.boolVariation(any(), eq(ldContextMock), anyBoolean()))
+        when(ldClientMock.boolVariation(
+                    eq(FeatureToggleServiceImpl.PAYMENT_LOOKUP_FEATURE),
+                    eq(ldContextMock),
+                    anyBoolean()))
                 .thenReturn(expected);
 
         final boolean actual = featureToggleService.useCcdLookupForPayments();
 
-        verify(ldClientMock).boolVariation(any(), eq(ldContextMock), anyBoolean());
+        verify(ldClientMock).boolVariation(
+                eq(FeatureToggleServiceImpl.PAYMENT_LOOKUP_FEATURE),
+                eq(ldContextMock),
+                anyBoolean());
         assertThat(actual, equalTo(expected));
     }
 }

--- a/src/test/java/uk/gov/hmcts/probate/core/service/FeatureToggleServiceImplTest.java
+++ b/src/test/java/uk/gov/hmcts/probate/core/service/FeatureToggleServiceImplTest.java
@@ -1,0 +1,55 @@
+package uk.gov.hmcts.probate.core.service;
+
+import com.launchdarkly.sdk.LDContext;
+import com.launchdarkly.sdk.server.interfaces.LDClientInterface;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class FeatureToggleServiceImplTest {
+    @Mock
+    LDClientInterface ldClientMock;
+    @Mock
+    LDContext ldContextMock;
+
+    FeatureToggleServiceImpl featureToggleService;
+
+    AutoCloseable closeableMocks;
+
+    @BeforeEach
+    void setUp() {
+        closeableMocks = MockitoAnnotations.openMocks(this);
+
+        featureToggleService = new FeatureToggleServiceImpl(
+                ldClientMock,
+                ldContextMock);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        closeableMocks.close();
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void lookupFromLDWhenCcdPaymentQueried(final boolean expected) {
+        when(ldClientMock.boolVariation(any(), eq(ldContextMock), anyBoolean()))
+                .thenReturn(expected);
+
+        final boolean actual = featureToggleService.useCcdLookupForPayments();
+
+        verify(ldClientMock).boolVariation(any(), eq(ldContextMock), anyBoolean());
+        assertThat(actual, equalTo(expected));
+    }
+}


### PR DESCRIPTION
### Jira link
See [DTSPB-5046](https://tools.hmcts.net/jira/browse/DTSPB-5046)

### Change description
Adds handling for feature toggles to the orchestrator service. Then alters existing case lookup behaviour for payments for caveats to use the lookup by ccd case reference rather than by the applicationId stored in the case data. this means we are more tolerant to issues when ES is offline/having issues.

### Testing done
Tested locally as well as in preview environments with both frontends deployed and feature toggled on/off.

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
